### PR TITLE
Add babel to npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,13 @@
     "url": "https://github.com/seegno/sei16.git"
   },
   "devDependencies": {
+    "babel-core": "6.4.5",
     "babel-eslint": "4.1.6",
+    "babel-loader": "6.2.1",
+    "babel-polyfill": "6.3.14",
+    "babel-preset-es2015": "6.3.13",
+    "babel-preset-react": "6.3.13",
+    "babel-preset-stage-1": "6.3.13",
     "eslint": "1.10.3",
     "eslint-config-react": "1.1.1",
     "eslint-config-seegno": "1.2.1",


### PR DESCRIPTION
This PR adds [babel](http://babeljs.io/) to npm dependencies.
