### PR TITLE
Add koa-socket missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "debug": "2.2.0",
     "koa": "1.1.2",
     "koa-router": "5.3.0",
+    "koa-socket": "4.0.0",
     "koa-views": "4.0.1",
     "lodash": "4.0.1",
     "react": "0.14.6",


### PR DESCRIPTION
This PR adds `koa-socket` missing dependency that is used in the API server.
