### PR TITLE
Remove the use of spread operator

### DIFF
--- a/src/api/managers/message-manager.js
+++ b/src/api/managers/message-manager.js
@@ -25,7 +25,7 @@ class MessageManager {
    */
 
   addMessage(message) {
-    this.messages = [message, ...this.messages.slice(0, 4)];
+    this.messages = _.concat([message], this.messages.slice(0, 4));
   }
 
   /**

--- a/src/api/managers/user-manager.js
+++ b/src/api/managers/user-manager.js
@@ -25,7 +25,7 @@ class UserManager {
    */
 
   addUser(user) {
-    this.users = [...this.users, user];
+    this.users = _.concat(this.users, [user]);
   }
 
   /**


### PR DESCRIPTION
This PR removes the use of spread operator to have compatibility with older versions of Node.JS
