### PR TITLE
Add eslint rule to disable require yield

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -44,3 +44,4 @@ rules:
   # Babel plugin
   babel/arrow-parens: 0
   babel/generator-star-spacing: 0
+  babel/require-yield: 0


### PR DESCRIPTION
This PR adds a new eslint rule to disable require yield on generator functions. This is necessary since we are using `koa-router` but our managers doesn't returns generators.
