### PR TITLE
Add required dependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "commander": "2.9.0",
     "config": "1.19.0",
     "debug": "2.2.0",
+    "enumify": "1.0.4",
     "json-mask": "0.3.5",
     "koa": "1.1.2",
     "koa-cors": "0.0.16",
@@ -56,13 +57,15 @@
     "koa-socket": "4.0.0",
     "koa-views": "4.0.1",
     "lodash": "4.0.1",
+    "qs": "6.0.2",
     "react": "0.14.6",
     "react-dom": "0.14.6",
     "react-redux": "4.0.6",
     "react-router": "2.0.0-rc5",
     "react-router-redux": "2.1.0",
     "redux": "3.0.5",
-    "redux-thunk": "1.0.3"
+    "redux-thunk": "1.0.3",
+    "socket.io-client": "1.4.5"
   },
   "pre-commit": {
     "run": [


### PR DESCRIPTION
This PR adds all required dependencies so there's no need to run `npm install` command during the workshop.
