### PR TITLE
Update eslint to disable react/jsx-no-bind rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -20,7 +20,7 @@ rules:
   react/jsx-curly-spacing: 2
   react/jsx-indent-props: [1, 2]
   react/jsx-max-props-per-line: 2
-  react/jsx-no-bind: 2
+  react/jsx-no-bind: 0
   react/jsx-no-duplicate-props: 2
   react/jsx-no-literals: 2
   react/jsx-no-undef: 2


### PR DESCRIPTION
This PR updates `react/jsx-no-bind` on eslint rules. This allows binding methods on component props, since we're using es2015 class syntax for component declarations, which doesn't have auto-bindings.
This enables the following:

``` js
return (
  <button onClick={this.onClick.bind(this)} />
);
```
